### PR TITLE
Filter design docs

### DIFF
--- a/cloudant-spark-sql/src/main/scala/com/cloudant/spark/CloudantConfig.scala
+++ b/cloudant-spark-sql/src/main/scala/com/cloudant/spark/CloudantConfig.scala
@@ -60,6 +60,8 @@ as the filter today does not tell how to link the filters out And v.s. Or
   def allowPartition(): Boolean = {indexName==null}
     
   def getOneUrl(): String = { dbUrl+ "/_all_docs?limit=1&include_docs=true"}
+  def getOneUrlExcludeDDoc1(): String = { dbUrl+ "/_all_docs?endkey=%22_design/%22&limit=1&include_docs=true"}
+  def getOneUrlExcludeDDoc2(): String = { dbUrl+ "/_all_docs?startkey=%22_design0/%22&limit=1&include_docs=true"}
     
   def getRangeUrl(field: String = null, start: Any = null, 
       startInclusive:Boolean = false, end:Any =null, 

--- a/cloudant-spark-sql/src/main/scala/com/cloudant/spark/DefaultSource.scala
+++ b/cloudant-spark-sql/src/main/scala/com/cloudant/spark/DefaultSource.scala
@@ -85,19 +85,12 @@ class DefaultSource extends RelationProvider with CreatableRelationProvider with
       val schema: StructType = {
         if (inSchema!=null) inSchema
         else{
-          try{
             val dataAccess = new JsonStoreDataAccess(config)
             val aRDD = sqlContext.sparkContext.parallelize(dataAccess.getOne())
             sqlContext.read.json(aRDD).schema
-          }catch
-          {
-            // We may not be able to derive a schema if it is an empty database
-            case e: Throwable => logger.info(s"Cannot load schema:$e")
-            null
-          }
         }
       }
-  
+
       CloudantReadWriteRelation(config, schema)(sqlContext)
     }
   

--- a/cloudant-spark-sql/src/main/scala/com/cloudant/spark/common/FilterUil.scala
+++ b/cloudant-spark-sql/src/main/scala/com/cloudant/spark/common/FilterUil.scala
@@ -128,7 +128,6 @@ class FilterUtil(filters: Map[String, Array[Filter]]) {
   implicit val system = SparkEnv.get.actorSystem
   private val logger = Logging(system, getClass)
   def apply(implicit r: JsValue = null): Boolean = {
-
     if (r == null) return true
     val satisfied = filters.forall({
       case (attr, filters) => {
@@ -141,8 +140,21 @@ class FilterUtil(filters: Map[String, Array[Filter]]) {
         }
       }
     })
-
     satisfied
   }
 }
+
+
+object FilterDDocs {
+  def filter(row: JsValue): Boolean = {
+    if (row == null) return true
+    val id : String = JsonUtil.getField(row, "_id").
+        getOrElse(null).as[JsString].value
+    if (id.startsWith("_design"))
+      false
+    else
+      true
+  }
+}
+
 


### PR DESCRIPTION
Filter design docs after there were received from Cloudant:
1. Added function FilterDDocs.filter in FilterUtil,
   so that a filter can be applied in JsonStoreDataAccess
2. Modified function JsonStoreDataAccess.getOne()
 to retrieve one NOT ddoc document.
 Because usual (not design docs) can have an _id that is bigger

> _design and also ids that is smaller than _design, had to use
>  two functions to retrieve non design documents:
>  getOneUrlExcludeDDoc1() and getOneUrlExcludeDDoc2()

BugzID: 56450
