### PR TITLE
Add option schemaSampleSize and accept values as per FB case

### DIFF
--- a/cloudant-spark-sql/src/main/resources/application.conf
+++ b/cloudant-spark-sql/src/main/resources/application.conf
@@ -14,5 +14,6 @@ spark-sql {
   		requestTimeout = 100000
   		concurrentSave = -1
   		bulkSize = 1
+  		schemaSampleSize = 1
   	}
 }

--- a/cloudant-spark-sql/src/main/scala/com/cloudant/spark/CloudantConfig.scala
+++ b/cloudant-spark-sql/src/main/scala/com/cloudant/spark/CloudantConfig.scala
@@ -28,7 +28,7 @@ Only allow one field pushdown now
 as the filter today does not tell how to link the filters out And v.s. Or
 */
 @serializable class CloudantConfig(val host: String, val dbName: String,
-    val indexName: String = null)
+    val indexName: String = null, val schemaSampleSize: Int = JsonStoreConfigManager.defaultSchemaSampleSize)
     (implicit val username: String, val password: String,
      val partitions:Int, val maxInPartition: Int, val minInPartition:Int,
      val requestTimeout:Long,val concurrentSave:Int, val bulkSize: Int) {
@@ -44,6 +44,10 @@ as the filter today does not tell how to link the filters out And v.s. Or
   def getLastUrl(skip: Int): String = {
     if (skip ==0 ) null
     else s"$dbUrl/$defaultIndex?limit=$skip"
+  }
+
+  def getSchemaSampleSize(): Int = {
+    schemaSampleSize
   }
   
   def getLastNum(result: JsValue): JsValue = {result \ "last_seq"}
@@ -62,6 +66,14 @@ as the filter today does not tell how to link the filters out And v.s. Or
   def getOneUrl(): String = { dbUrl+ "/_all_docs?limit=1&include_docs=true"}
   def getOneUrlExcludeDDoc1(): String = { dbUrl+ "/_all_docs?endkey=%22_design/%22&limit=1&include_docs=true"}
   def getOneUrlExcludeDDoc2(): String = { dbUrl+ "/_all_docs?startkey=%22_design0/%22&limit=1&include_docs=true"}
+
+  def getAllDocsUrl(limit: Int): String = {
+    if (limit == JsonStoreConfigManager.SCHEMA_FOR_ALL_DOCS_NUM) {
+      dbUrl + "/_all_docs?include_docs=true"
+    } else {
+      dbUrl + "/_all_docs?limit=" + limit + "&include_docs=true"
+    }
+  }
     
   def getRangeUrl(field: String = null, start: Any = null, 
       startInclusive:Boolean = false, end:Any =null, 

--- a/cloudant-spark-sql/src/main/scala/com/cloudant/spark/DefaultSource.scala
+++ b/cloudant-spark-sql/src/main/scala/com/cloudant/spark/DefaultSource.scala
@@ -86,7 +86,7 @@ class DefaultSource extends RelationProvider with CreatableRelationProvider with
         if (inSchema!=null) inSchema
         else{
             val dataAccess = new JsonStoreDataAccess(config)
-            val aRDD = sqlContext.sparkContext.parallelize(dataAccess.getOne())
+            val aRDD = sqlContext.sparkContext.parallelize(dataAccess.getMany(config.getSchemaSampleSize()))
             sqlContext.read.json(aRDD).schema
         }
       }

--- a/cloudant-spark-sql/src/main/scala/com/cloudant/spark/common/JsonStoreDataAccess.scala
+++ b/cloudant-spark-sql/src/main/scala/com/cloudant/spark/common/JsonStoreDataAccess.scala
@@ -68,6 +68,24 @@ class JsonStoreDataAccess (config: CloudantConfig)  {
     }
   }
 
+  def getMany(limit: Int)(implicit columns: Array[String] = null) = {
+    if(limit == 0){
+      throw new RuntimeException("Database " + config.getDbname() +
+        " schema sample size is 0!")
+    }
+    if(limit < -1){
+      throw new RuntimeException("Database " + config.getDbname() +
+        " schema sample size is " + limit + "!")
+    }
+    var r = this.getQueryResult[Seq[String]](config.getAllDocsUrl(limit), processAll)
+    if (r.size == 0) {
+      throw new RuntimeException("Database " + config.getDbname() +
+        " doesn't have any non-design documents!")
+    }else {
+      r
+    }
+  }
+
   def getAll[T](url: String)
       (implicit columns: Array[String] = null,
       attrToFilters: Map[String, Array[Filter]] =null) = {


### PR DESCRIPTION
BugzId: 59236

Test by either adding a global schemaSampleSize configuration directly to your Spark context ....

```
conf = SparkConf().setAppName("Multiple schema test")

conf.set("schemaSampleSize", -1)

sc = SparkContext(conf=conf)
sqlContext = SQLContext(sc)
```

.. or locally as option for the individual RDD like:

`sqlContext.sql("CREATE TEMPORARY TABLE kang_test_2 USING com.cloudant.spark.CloudantRP OPTIONS ( schemaSampleSize '-1',database 'kang_test_2')")`
