### PR TITLE
Fixed the 'non-design documents' issue

### DIFF
--- a/cloudant-spark-sql/src/main/scala/com/cloudant/spark/CloudantConfig.scala
+++ b/cloudant-spark-sql/src/main/scala/com/cloudant/spark/CloudantConfig.scala
@@ -67,6 +67,10 @@ as the filter today does not tell how to link the filters out And v.s. Or
   def getOneUrlExcludeDDoc1(): String = { dbUrl+ "/_all_docs?endkey=%22_design/%22&limit=1&include_docs=true"}
   def getOneUrlExcludeDDoc2(): String = { dbUrl+ "/_all_docs?startkey=%22_design0/%22&limit=1&include_docs=true"}
 
+  def getAllDocsUrlExcludeDDoc(limit: Int): String = {
+    dbUrl + "/_all_docs?startkey=%22_design0/%22&limit=" + limit + "&include_docs=true"
+  }
+  
   def getAllDocsUrl(limit: Int): String = {
     if (limit == JsonStoreConfigManager.SCHEMA_FOR_ALL_DOCS_NUM) {
       dbUrl + "/_all_docs?include_docs=true"

--- a/cloudant-spark-sql/src/main/scala/com/cloudant/spark/common/JsonStoreDataAccess.scala
+++ b/cloudant-spark-sql/src/main/scala/com/cloudant/spark/common/JsonStoreDataAccess.scala
@@ -79,6 +79,9 @@ class JsonStoreDataAccess (config: CloudantConfig)  {
     }
     var r = this.getQueryResult[Seq[String]](config.getAllDocsUrl(limit), processAll)
     if (r.size == 0) {
+      r = this.getQueryResult[Seq[String]](config.getAllDocsUrlExcludeDDoc(limit), processAll)
+    }
+    if (r.size == 0) {
       throw new RuntimeException("Database " + config.getDbname() +
         " doesn't have any non-design documents!")
     }else {


### PR DESCRIPTION
It's natural that the connector throw a 'non-design documents' exception when the Cloudant database is empty or just contains '_design' docs. The issue is that the connector might throw this exception as well when the database contains both '_design' docs and non-design docs.
To fix this issue, changed the logic of 'getMany' method to:
1. Get the docs by the Cloudant '_all_docs' API.
2. Try to get the docs again if 1 returns a empty list, but this time it will use 'startkey' to filter the '_design' documents.

BugzID: 59236
