### PR TITLE
Correct retrieval of doc objects form Cloudant _all_docs response

### DIFF
--- a/cloudant-spark-sql/src/main/scala/com/cloudant/spark/CloudantConfig.scala
+++ b/cloudant-spark-sql/src/main/scala/com/cloudant/spark/CloudantConfig.scala
@@ -16,6 +16,7 @@
 package com.cloudant.spark
 
 import play.api.libs.json.JsValue
+import play.api.libs.json.JsArray
 import play.api.libs.json.Json
 import play.api.libs.json.JsUndefined
 import java.net.URLEncoder
@@ -168,7 +169,7 @@ as the filter today does not tell how to link the filters out And v.s. Or
   }
     
   def getRows(result: JsValue): Seq[JsValue] = {
-    result \\ "doc"
+    ((result \ "rows").asInstanceOf[JsArray]).value.map(row => row \ "doc")
   }
     
   def getBulkPostUrl(): String = {


### PR DESCRIPTION
Before the line `result` \"doc"`would retrieve not only`doc`objects under`rows`,
but also all interal objects

BugzId: 59832
