### PR TITLE
Loading data from views

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Persisting will also speed up computation. This statement will persist an RDD in
 from pyspark import StorageLevel
 df.persist(storageLevel = StorageLevel(True, True, False, True, 1))
 ```	
-	
+
 [Sample code on using DataFrame option to define cloudant configuration](examples/python/CloudantDFOption.py)
 	
 ### Using DataFrame In Scala 
@@ -221,9 +221,16 @@ Configuration can also be passed on DataFrame using option.
 Name | Default | Meaning
 --- |:---:| ---
 database||cloudant database name
-index||cloudant search index w/o the database name.only used for load.
+view||cloudant view w/o the database name. only used for load.
+index||cloudant search index w/o the database name. only used for load data with less than or equal to 200 results.
 path||cloudant: as database name if database is not present
 schemaSampleSize|1| the sample size used to discover the schema for this temp table. -1 scans all documents
+
+Loading data from views is available only for `DefaultSource` provider. For fast loading, views are loaded without include_docs. Thus, a derived schema will always be: `{id, key, value}`, where `value `can be a compount field. An example of loading data from a view: 
+
+```python
+sqlContext.sql(" CREATE TEMPORARY TABLE flightTable1 USING com.cloudant.spark OPTIONS ( database 'n_flight', view '_design/view/_view/AA0')")
+```
 
 ## Troubleshooting
 

--- a/cloudant-spark-sql/src/main/scala/com/cloudant/spark/CloudantDatasource.scala
+++ b/cloudant-spark-sql/src/main/scala/com/cloudant/spark/CloudantDatasource.scala
@@ -33,7 +33,7 @@ case class CloudantTableScan (dbName: String, schemaSampleSize: String = null)
       new JsonStoreDataAccess(config) }
   
   lazy val config: CloudantConfig = {
-    JsonStoreConfigManager.getConfig(sqlContext, dbName, null, schemaSampleSize).asInstanceOf[CloudantConfig]
+    JsonStoreConfigManager.getConfig(sqlContext, dbName, null, null, schemaSampleSize).asInstanceOf[CloudantConfig]
   }
 
   val schema: StructType = {

--- a/cloudant-spark-sql/src/main/scala/com/cloudant/spark/CloudantPartitionedPrunedFilteredDatasource.scala
+++ b/cloudant-spark-sql/src/main/scala/com/cloudant/spark/CloudantPartitionedPrunedFilteredDatasource.scala
@@ -32,12 +32,12 @@ import com.cloudant.spark.common._
 /**
  * @author yanglei
  */
-case class CloudantPartitionedPrunedFilteredScan (dbName: String, indexName: String = null, schemaSampleSize: String = null)
+case class CloudantPartitionedPrunedFilteredScan (dbName: String, indexName: String = null, viewName: String = null,schemaSampleSize: String = null)
                       (@transient val sqlContext: SQLContext) 
   extends BaseRelation with PrunedFilteredScan 
 {
   lazy val config: CloudantConfig = {
-    JsonStoreConfigManager.getConfig(sqlContext, dbName, indexName, schemaSampleSize).asInstanceOf[CloudantConfig]
+    JsonStoreConfigManager.getConfig(sqlContext, dbName, indexName, viewName, schemaSampleSize).asInstanceOf[CloudantConfig]
   }
   
   @transient lazy val dataAccess = {
@@ -77,7 +77,7 @@ class CloudantPartitionedPrunedFilteredRP extends RelationProvider {
   def createRelation(sqlContext: SQLContext, parameters: Map[String, String]) = {
     
     CloudantPartitionedPrunedFilteredScan(
-      parameters("database"), parameters.getOrElse("index",null), parameters.getOrElse(JsonStoreConfigManager.PARAM_SCHEMA_SAMPLE_SIZE_CONFIG, null))(sqlContext)
+      parameters("database"), parameters.getOrElse("index",null), parameters.getOrElse("view",null), parameters.getOrElse(JsonStoreConfigManager.PARAM_SCHEMA_SAMPLE_SIZE_CONFIG, null))(sqlContext)
   }
   
 }

--- a/cloudant-spark-sql/src/main/scala/com/cloudant/spark/CloudantPrunedFilteredDatasource.scala
+++ b/cloudant-spark-sql/src/main/scala/com/cloudant/spark/CloudantPrunedFilteredDatasource.scala
@@ -27,7 +27,7 @@ import com.cloudant.spark.common._
  * @author yanglei
  */
 
-case class CloudantPrunedFilteredScan (dbName: String, indexName: String, schemaSampleSize: String = null)
+case class CloudantPrunedFilteredScan (dbName: String, indexName: String,  viewName:String, schemaSampleSize: String = null)
                       (@transient val sqlContext: SQLContext) 
   extends BaseRelation with PrunedFilteredScan 
 {
@@ -36,7 +36,7 @@ case class CloudantPrunedFilteredScan (dbName: String, indexName: String, schema
   }
   
   lazy val config: CloudantConfig = {
-    JsonStoreConfigManager.getConfig(sqlContext, dbName, indexName, schemaSampleSize).asInstanceOf[CloudantConfig]
+    JsonStoreConfigManager.getConfig(sqlContext, dbName, indexName, viewName, schemaSampleSize).asInstanceOf[CloudantConfig]
   }
 
   val schema: StructType = {
@@ -68,7 +68,7 @@ class CloudantPrunedFilteredRP extends RelationProvider {
 
   def createRelation(sqlContext: SQLContext, parameters: Map[String, String]) = {
     CloudantPrunedFilteredScan(
-      parameters("database"),parameters.getOrElse("index",null), parameters.getOrElse(JsonStoreConfigManager.PARAM_SCHEMA_SAMPLE_SIZE_CONFIG, null))(sqlContext)
+      parameters("database"),parameters.getOrElse("index",null), parameters.getOrElse("view",null), parameters.getOrElse(JsonStoreConfigManager.PARAM_SCHEMA_SAMPLE_SIZE_CONFIG, null))(sqlContext)
   }
   
 }

--- a/cloudant-spark-sql/src/main/scala/com/cloudant/spark/common/JsonStoreConfigManager.scala
+++ b/cloudant-spark-sql/src/main/scala/com/cloudant/spark/common/JsonStoreConfigManager.scala
@@ -58,7 +58,7 @@ import com.cloudant.spark.CloudantConfig
     }
   }
   
-  def getConfig(context: SQLContext, dbName: String, indexName:String = null, schemaSampleSize: String): CloudantConfig = {
+  def getConfig(context: SQLContext, dbName: String, indexName:String = null, viewName:String = null, schemaSampleSize: String): CloudantConfig = {
       val sparkConf = context.sparkContext.getConf
       implicit val total = sparkConf.getInt(PARTITION_CONFIG,defaultPartitions)
       implicit val max = sparkConf.getInt(MAX_IN_PARTITION_CONFIG,defaultMaxInPartition)
@@ -82,7 +82,7 @@ import com.cloudant.spark.CloudantConfig
       val passwd = if (sparkConf.contains(CLOUDANT_PASSWORD_CONFIG)) sparkConf.get(CLOUDANT_PASSWORD_CONFIG) else null
       
       if (host != null) {
-        return new CloudantConfig(protocol, host,  dbName, indexName, intSchemaSampleSize)(user, passwd, total, max, min,requestTimeout,concurrentSave, bulkSize)
+        return new CloudantConfig(protocol, host,  dbName, indexName, viewName, intSchemaSampleSize)(user, passwd, total, max, min,requestTimeout,concurrentSave, bulkSize)
       }else{
         throw new RuntimeException("Spark configuration is invalid! Please make sure to supply required values for cloudant.host.")
       }
@@ -110,6 +110,7 @@ import com.cloudant.spark.CloudantConfig
 
       val dbName = parameters.getOrElse("database", parameters.getOrElse("path",null))
       val indexName = parameters.getOrElse("index",null)
+      val viewName = parameters.getOrElse("view", null)
 
       var schemaSampleSize = parameters.getOrElse(PARAM_SCHEMA_SAMPLE_SIZE_CONFIG, null)
       if (schemaSampleSize == null && sparkConf.contains(SCHEMA_SAMPLE_SIZE_CONFIG) ) {
@@ -118,7 +119,7 @@ import com.cloudant.spark.CloudantConfig
       
       val intSchemaSampleSize = calculateSchemaSampleSize(schemaSampleSize);
       
-      println(s"Use dbName=$dbName, indexName=$indexName, $PARTITION_CONFIG=$total, $MAX_IN_PARTITION_CONFIG=$max, $MIN_IN_PARTITION_CONFIG=$min, $REQUEST_TIMEOUT_CONFIG=$requestTimeout,$CONCURRENT_SAVE_CONFIG=$concurrentSave,$BULK_SIZE_CONFIG=$bulkSize,$SCHEMA_SAMPLE_SIZE_CONFIG=$intSchemaSampleSize")
+      println(s"Use dbName=$dbName, indexName=$indexName, viewName=$viewName, $PARTITION_CONFIG=$total, $MAX_IN_PARTITION_CONFIG=$max, $MIN_IN_PARTITION_CONFIG=$min, $REQUEST_TIMEOUT_CONFIG=$requestTimeout,$CONCURRENT_SAVE_CONFIG=$concurrentSave,$BULK_SIZE_CONFIG=$bulkSize,$SCHEMA_SAMPLE_SIZE_CONFIG=$intSchemaSampleSize")
 
       val protocolParam = parameters.getOrElse(CLOUDANT_PROTOCOL_CONFIG, null)
       val hostParam = parameters.getOrElse(CLOUDANT_HOST_CONFIG, null)
@@ -129,7 +130,7 @@ import com.cloudant.spark.CloudantConfig
       val user = if (userParam == null) sparkConf.get(CLOUDANT_USERNAME_CONFIG, null) else userParam
       val passwd = if (passwdParam == null) sparkConf.get(CLOUDANT_PASSWORD_CONFIG, null) else passwdParam
       if (host != null) {
-        return new CloudantConfig(protocol, host, dbName, indexName, intSchemaSampleSize)(user, passwd, total, max, min, requestTimeout, concurrentSave, bulkSize)
+        return new CloudantConfig(protocol, host, dbName, indexName, viewName, intSchemaSampleSize)(user, passwd, total, max, min, requestTimeout, concurrentSave, bulkSize)
       } else {
         throw new RuntimeException("Spark configuration is invalid! Please make sure to supply required values for cloudant.host.")
       }

--- a/cloudant-spark-sql/src/main/scala/com/cloudant/spark/common/JsonStoreDataAccess.scala
+++ b/cloudant-spark-sql/src/main/scala/com/cloudant/spark/common/JsonStoreDataAccess.scala
@@ -122,8 +122,10 @@ class JsonStoreDataAccess (config: CloudantConfig)  {
     logger.debug(s"processAll columns:$columns, attrToFilters:$attrToFilters")
     val jsonResult = Json.parse(result)
     var rows = config.getRows(jsonResult)
-    //filter design docs
-    rows = rows.filter(r => FilterDDocs.filter(r))
+    if (config.viewName == null) {
+      //filter design docs
+      rows = rows.filter(r => FilterDDocs.filter(r))
+    }
     rows.map(r => convert(r))
   }
       
@@ -167,7 +169,7 @@ class JsonStoreDataAccess (config: CloudantConfig)  {
   private def getQueryResult[T](url: String, postProcessor:(String) => T)
       (implicit columns: Array[String] = null, 
       attrToFilters: Map[String, Array[Filter]] =null) : T={
-    logger.info("Loading data from Cloudant using query: "+ url)
+    logger.warning("Loading data from Cloudant using query: "+ url)
     implicit val ( system, existing) = getSystem()
 
     val request: HttpRequest = if (validCredentials != null) {

--- a/examples/python/CloudantDF.py
+++ b/examples/python/CloudantDF.py
@@ -58,3 +58,8 @@ df.printSchema()
 
 total = df.filter(df.flightSegmentId >'AA9').select("flightSegmentId", "scheduledDepartureTime").orderBy(df.flightSegmentId).count()
 print "Total", total, "flights from index"
+
+# Loading data from views
+df = sqlContext.load(source="com.cloudant.spark", path="movies-glynn", view="_design/view1/_view/titleyear2")
+df.printSchema()
+df.filter(df.value.year >= 1950).select(df.value.title.alias("title"), df.value.year.alias("year")).show()

--- a/examples/scala/src/main/scala/mytest/spark/CloudantDF.scala
+++ b/examples/scala/src/main/scala/mytest/spark/CloudantDF.scala
@@ -21,6 +21,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.storage.StorageLevel
 
+
 /**
  * @author yanglei
  */
@@ -62,5 +63,11 @@ object CloudantDF{
         val df3 = sqlContext.read.format("com.cloudant.spark").option("index", "_design/view/_search/n_flights").load("n_flight")
         val total2 = df3.filter(df3("flightSegmentId") >"AA9").select("flightSegmentId", "scheduledDepartureTime").orderBy(df3("flightSegmentId")).count()
         println(s"Total $total2 flights from index")
+
+        // Loading data from views
+        val df4 = sqlContext.read.format("com.cloudant.spark").option("view", "_design/view1/_view/titleyear2").load("movies-glynn")
+        df4.printSchema()
+        import sqlContext.implicits._
+        df4.filter($"value.year" >= 1930).select($"value.title", $"value.year").show()
 }
 }

--- a/test/helpers/db-index-func/n_flight.txt
+++ b/test/helpers/db-index-func/n_flight.txt
@@ -1,1 +1,9 @@
-{"_id":"_design/view","views":{},"language":"javascript","indexes":{"n_flights":{"analyzer":"standard","index":"function(doc){\n\t    index(\"default\", doc._id);\n    \t    if(doc.flightSegmentId){\n           \tindex(\"flightSegmentId\", doc.flightSegmentId, {\"store\": \"yes\"});\n    \t    }\n    \t    if(doc.scheduledDepartureTime){\n           \tindex(\"scheduledDepartureTime\", doc.scheduledDepartureTime, {\"store\": \"yes\"});\n    \t    }\n}"}}}
+{"_id":"_design/view","views":{     "AA0": {
+              "map": "function (doc) {\n  if ((doc.flightSegmentId !== null)\n  && (doc.flightSegmentId == \"AA0\")) {\n    emit(doc.flightSegmentId,doc.scheduledDepartureTime);\n  }\n}"
+            },
+            "AA1": {
+              "map": "function (doc) {\n  if ((doc.flightSegmentId !== null)\n  && (doc.flightSegmentId == \"AA1\")) {\n    emit(doc.flightSegmentId,doc.scheduledDepartureTime);\n  }\n}"
+            },
+            "AA2": {
+              "map": "function (doc) {\n  if ((doc.flightSegmentId !== null)\n  && (doc.flightSegmentId == \"AA2\")) {\n    emit(doc.flightSegmentId,doc.scheduledDepartureTime);\n  }\n}"
+            }},"language":"javascript","indexes":{"n_flights":{"analyzer":"standard","index":"function(doc){\n\t    index(\"default\", doc._id);\n    \t    if(doc.flightSegmentId){\n           \tindex(\"flightSegmentId\", doc.flightSegmentId, {\"store\": \"yes\"});\n    \t    }\n    \t    if(doc.scheduledDepartureTime){\n           \tindex(\"scheduledDepartureTime\", doc.scheduledDepartureTime, {\"store\": \"yes\"});\n    \t    }\n}"}}}

--- a/test/test-scripts/cloudantapp/ViewOption.py
+++ b/test/test-scripts/cloudantapp/ViewOption.py
@@ -1,0 +1,62 @@
+#*******************************************************************************
+# Copyright (c) 2015 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#******************************************************************************/
+from pyspark.sql import SQLContext
+from pyspark import SparkContext, SparkConf
+import requests
+import sys
+from os.path import dirname as dirname
+# add /test to pythonpath so utils can be imported when running from spark
+sys.path.append(dirname(dirname(dirname(__file__))))
+import helpers.utils as utils
+
+conf = utils.createSparkConf()
+sc = SparkContext(conf=conf)
+sqlContext = SQLContext(sc)
+
+def verifyViewOption():
+	flightData = sqlContext.sql("SELECT key, value FROM flightTable1 WHERE key = 'AA0'")
+	flightData.printSchema()
+
+	# verify expected count
+	print ("flightData.count() = ", flightData.count())
+	assert flightData.count() == total_rows
+
+	# verify key = "AA0'
+	for flight in flightData.collect():
+		print ('Flight {0} on {1}'.format(flight.key, flight.value))
+		assert flight.key =='AA0'
+
+
+# query the index using Cloudant API to get expected count
+test_properties = utils.get_test_properties()
+url = "https://"+test_properties["cloudanthost"]+"/n_flight/_design/view/_view/AA0"
+response = requests.get(url, auth=(test_properties["cloudantusername"], test_properties["cloudantpassword"]))
+assert response.status_code == 200
+total_rows = response.json().get("total_rows")
+
+
+print ('About to test com.cloudant.spark for n_flight with view')
+sqlContext.sql(" CREATE TEMPORARY TABLE flightTable1 USING com.cloudant.spark OPTIONS ( database 'n_flight', view '_design/view/_view/AA0')")
+verifyViewOption()
+
+
+
+	
+
+
+	
+	
+

--- a/test/test_cloudantapp.py
+++ b/test/test_cloudantapp.py
@@ -18,31 +18,35 @@ import os
 
 class TestCloudantSparkConnector:
 
-	script_dir = "test-scripts/cloudantapp"
-	
-	def test_SpecCharPredicate(self, sparksubmit):
-		script_name = "SpecCharPredicate.py"
-		helpers.utils.run_test(self.get_script_path(script_name), sparksubmit)
-		
-	def test_RegCharPredicate(self, sparksubmit):
-		script_name = "RegCharPredicate.py"
-		helpers.utils.run_test(self.get_script_path(script_name), sparksubmit)
-		
-	def test_RangePredicate(self, sparksubmit):
-		script_name = "RangePredicate.py"
-		helpers.utils.run_test(self.get_script_path(script_name), sparksubmit)	
+    script_dir = "test-scripts/cloudantapp"
 
-	def test_SpecCharValuePredicate(self, sparksubmit):
-		script_name = "SpecCharValuePredicate.py"
-		helpers.utils.run_test(self.get_script_path(script_name), sparksubmit)
+    def test_SpecCharPredicate(self, sparksubmit):
+        script_name = "SpecCharPredicate.py"
+        helpers.utils.run_test(self.get_script_path(script_name), sparksubmit)
+        
+    def test_RegCharPredicate(self, sparksubmit):
+        script_name = "RegCharPredicate.py"
+        helpers.utils.run_test(self.get_script_path(script_name), sparksubmit)
+        
+    def test_RangePredicate(self, sparksubmit):
+        script_name = "RangePredicate.py"
+        helpers.utils.run_test(self.get_script_path(script_name), sparksubmit)  
 
-	def test_IndexOption(self, sparksubmit):
-		script_name = "IndexOption.py"
-		helpers.utils.run_test(self.get_script_path(script_name), sparksubmit)		
-		
-	def get_script_path(self, script_name):
-		return os.path.join(os.path.dirname(__file__), self.script_dir, script_name)
-			
+    def test_SpecCharValuePredicate(self, sparksubmit):
+        script_name = "SpecCharValuePredicate.py"
+        helpers.utils.run_test(self.get_script_path(script_name), sparksubmit)
 
-		
+    def test_IndexOption(self, sparksubmit):
+        script_name = "IndexOption.py"
+        helpers.utils.run_test(self.get_script_path(script_name), sparksubmit)      
+    
+    def test_ViewOption(self, sparksubmit):
+        script_name = "ViewOption.py"
+        helpers.utils.run_test(self.get_script_path(script_name), sparksubmit)      
+    
+    def get_script_path(self, script_name):
+        return os.path.join(os.path.dirname(__file__), self.script_dir, script_name)
+            
+
+        
 


### PR DESCRIPTION
This commit allows to load data from Cloudant views to Spark

Usage: df = sqlContext.load(source="com.cloudant.spark",
path="movies-glynn", view="_design/view1/_view/titleyear2")

For fast loading, views are loaded without include_docs
Thus derived schema will always be: {id, key, value}

BugzId: 60495
