### PR TITLE
improve save parallelism, sharing actorSystem for the duration of the…

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,6 @@ jsonstore.rdd.partitions|5|the number of partitions intent used to drive JsonSto
 jsonstore.rdd.maxInPartition|-1|the max rows in a partition. -1 means unlimited
 jsonstore.rdd.minInPartition|10|the min rows in a partition.
 jsonstore.rdd.requestTimeout|100000| the request timeout in milli-second
-jsonstore.rdd.concurrentSave|-1| the parallel saving size. -1 means unlimited
 jsonstore.rdd.bulkSize|1| the bulk save size
 jsonstore.rdd.schemaSampleSize|1| the sample size for RDD schema discovery. -1 means unlimited
 

--- a/cloudant-spark-sql/src/main/resources/application.conf
+++ b/cloudant-spark-sql/src/main/resources/application.conf
@@ -28,9 +28,9 @@ dispatcher {
     # Min number of threads to cap factor-based parallelism number to
     parallelism-min = 10
     # Parallelism (threads) ... ceil(available processors * factor)
-    parallelism-factor = 25.0
+    parallelism-factor = 3.0
     # Max number of threads to cap factor-based parallelism number to
-    parallelism-max = 500
+    parallelism-max = 200
     }
     # Throughput defines the maximum number of messages to be
     # processed per actor before the thread jumps to the next actor.

--- a/cloudant-spark-sql/src/main/resources/application.conf
+++ b/cloudant-spark-sql/src/main/resources/application.conf
@@ -17,3 +17,25 @@ spark-sql {
   		schemaSampleSize = 1
   	}
 }
+
+dispatcher {
+    # Dispatcher is the name of the event-based dispatcher
+    type = Dispatcher
+    # What kind of ExecutionService to use
+    executor = "fork-join-executor"
+    # Configuration for the fork join pool
+    fork-join-executor {
+    # Min number of threads to cap factor-based parallelism number to
+    parallelism-min = 10
+    # Parallelism (threads) ... ceil(available processors * factor)
+    parallelism-factor = 25.0
+    # Max number of threads to cap factor-based parallelism number to
+    parallelism-max = 500
+    }
+    # Throughput defines the maximum number of messages to be
+    # processed per actor before the thread jumps to the next actor.
+    # Set to 1 for as fair as possible.
+    # set to 20 as I want each sequence to finish if it is possible
+    throughput = 1
+  }
+  

--- a/cloudant-spark-sql/src/main/scala/com/cloudant/spark/CloudantConfig.scala
+++ b/cloudant-spark-sql/src/main/scala/com/cloudant/spark/CloudantConfig.scala
@@ -22,6 +22,7 @@ import play.api.libs.json.JsUndefined
 import java.net.URLEncoder
 import com.cloudant.spark.common._
 import play.api.libs.json.JsNumber
+import akka.actor.ActorSystem
 
 /*
 @author yanglei
@@ -33,13 +34,21 @@ as the filter today does not tell how to link the filters out And v.s. Or
     val schemaSampleSize: Int = JsonStoreConfigManager.defaultSchemaSampleSize)
     (implicit val username: String, val password: String,
     val partitions:Int, val maxInPartition: Int, val minInPartition:Int,
-    val requestTimeout:Long,val concurrentSave:Int, val bulkSize: Int) {
+    val requestTimeout:Long,val bulkSize: Int) {
   
   private lazy val dbUrl = {protocol + "://"+ host+"/"+dbName}
 
   val pkField = "_id"
   val defaultIndex = "_all_docs" // "_changes" does not work for partition
   val default_filter: String = "*:*"
+
+  def getSystem(): ActorSystem  = {
+    JsonStoreConfigManager.getActorSystem()
+  }
+  
+  def shutdown() = {
+    JsonStoreConfigManager.shutdown()
+  }
 
   def getPostUrl(): String ={dbUrl}
   
@@ -195,8 +204,9 @@ as the filter today does not tell how to link the filters out And v.s. Or
     dbUrl + "/_bulk_docs"
   }
     
-  def getBulkRows(rows: Array[String]): String = {
+  def getBulkRows(rows: List[String]): String = {
     val docs = rows.map { x => Json.parse(x) }
     Json.stringify(Json.obj("docs" -> Json.toJson(docs.toSeq)))
   }
+ 
 }

--- a/cloudant-spark-sql/src/main/scala/com/cloudant/spark/DefaultSource.scala
+++ b/cloudant-spark-sql/src/main/scala/com/cloudant/spark/DefaultSource.scala
@@ -61,8 +61,11 @@ case class CloudantReadWriteRelation (config:CloudantConfig, schema: StructType 
     }
 
     def  insert( data:DataFrame, overwrite: Boolean) ={
-        //TODO parallel save
-        dataAccess.saveAll(data.toJSON.collect)
+      // Better parallelism 
+      val result = data.toJSON.foreachPartition { x =>
+            val list = x.toList // Has to pass as List, Iterator results in 0 data
+              dataAccess.saveAll(list)
+      }
     }
 }
 

--- a/cloudant-spark-sql/src/main/scala/com/cloudant/spark/common/JsonStoreDataAccess.scala
+++ b/cloudant-spark-sql/src/main/scala/com/cloudant/spark/common/JsonStoreDataAccess.scala
@@ -147,30 +147,11 @@ class JsonStoreDataAccess (config: CloudantConfig)  {
     result
   }
 
-  private def getSystem(): (ActorSystem, Boolean) = {
-    val checkSprayConfig = envSystem.settings.config.withFallback(ConfigFactory.parseString("""
-        spray = NOT_FOUND
-     """) )
-    val sprayValue = checkSprayConfig.getValue("spray").unwrapped().toString()
-    if ( !sprayValue.equals("NOT_FOUND")) // The env actorSystem loaded spary config
-    {
-      logger.info("reuse SparkEnv ActorSystem as it contains spray")
-      (envSystem, true)
-    }
-    else{
-      logger.info("create new ActorSystem as the SparkEnv one does not contain spray")
-      val classLoader = this.getClass.getClassLoader
-      val myconfig = ConfigFactory.load(classLoader)// force config from my classloader
-      val nextRamdomNum = new Random().nextInt
-        (ActorSystem("CloudantSpark-"+nextRamdomNum,myconfig,classLoader), false)
-    }
-  }
-  
   private def getQueryResult[T](url: String, postProcessor:(String) => T)
       (implicit columns: Array[String] = null, 
       attrToFilters: Map[String, Array[Filter]] =null) : T={
     logger.warning("Loading data from Cloudant using query: "+ url)
-    implicit val ( system, existing) = getSystem()
+    implicit val system = config.getSystem()
 
     val request: HttpRequest = if (validCredentials != null) {
       Get(url) ~> addCredentials(validCredentials)
@@ -187,20 +168,18 @@ class JsonStoreDataAccess (config: CloudantConfig)  {
     }
     val data = postProcessor(result.entity.asString)
     logger.debug(s"got result:$data")
-    if(!existing){
-      logger.info("shutdown newly created ActorSystem")
-      system.shutdown()
-    }
     data
   }
 
-  def saveAll(rows: Array[String]) {
-    implicit val (system, existing) = getSystem()
+  def saveAll(rows: List[String]) {
+    implicit val system = config.getSystem()
     import system.dispatcher 
     
     val useBulk = (config.getBulkPostUrl() != null && config.bulkSize>1)
     val bulkSize = if (useBulk) config.bulkSize else 1
     val bulks = rows.grouped(bulkSize).toList
+    val totalBulks = bulks.size
+    logger.info(s"total records:${rows.size}=bulkSize:$bulkSize * totalBulks:$totalBulks, execute in parallel $totalBulks")
     
     val url = if (bulkSize>1) config.getBulkPostUrl() else config.getPostUrl()
     logger.info(s"Post:$url")
@@ -210,17 +189,10 @@ class JsonStoreDataAccess (config: CloudantConfig)  {
     implicit val stringMarshaller = Marshaller.of[String](`application/json`) {
       (value, ct, ctx) => ctx.marshalTo(HttpEntity(ct, value))
     }
-    val parallelSize = if (config.concurrentSave>0) config.concurrentSave else bulks.size
-    val blocks = bulks.size/parallelSize + (if ( bulks.size % parallelSize != 0) 1 else 0)
-    
-    for (i <- 0 until blocks){
-      val start = parallelSize*i
-      val end = if (parallelSize+start<bulks.size) parallelSize+start else bulks.size
-      logger.info(s"Save from $start to ${end-1} for bulkSize=$bulkSize and paralellSize=$parallelSize at ${i+1}/$blocks")
-      val allFutures =  { 
-        for ( j <- start until end) yield
-        {
-          val  x: String = if (bulkSize >1) config.getBulkRows(bulks(j)) else bulks(j)(0)
+    // Better parallelism 
+    val allFutures : List[Future[HttpResponse]] =  { 
+        for (bulk <- bulks) yield {
+          val  x: String = if (bulkSize >1) config.getBulkRows(bulk) else bulk(0)
           logger.debug(s"content:$x")
           var pipeline: HttpRequest => Future[HttpResponse] = null
           if (validCredentials!=null)
@@ -235,21 +207,17 @@ class JsonStoreDataAccess (config: CloudantConfig)  {
           }
           val request = Post(url,x)
           val response: Future[HttpResponse] = pipeline(request)
-            response
-          } 
-      }
-      val f = Future.sequence(allFutures.toList)
-      val result = Await.result(f, timeout.duration)
-      val isSuccessful= result.forall { x => x.status.isSuccess }
-      if(!existing)
-      {
-        logger.info("shutdown newly created ActorSystem")
-        system.shutdown()
-      }
-      logger.info(s"Save total ${end-start}=${result.length} successful=$isSuccessful")
-      if (!isSuccessful)
-         throw new RuntimeException("Database " + config.getDbname() +
-          " does not exist or is not accessible. Failed to save data!")
+          response
+        }
+    }
+    val f = Future.sequence(allFutures.toList)
+    val result = Await.result(f, timeout.duration)
+    var reason : String = null
+    val isSuccessful= result.forall { x => if( !x.status.isSuccess ) reason= x.status.reason;x.status.isSuccess }
+    logger.info(s"Save total ${totalBulks}=${result.length} successful=$isSuccessful")
+    if (!isSuccessful)
+    {
+         throw new RuntimeException(s"Database ${config.getDbname()} faield with $reason")
     }
   }
 }

--- a/examples/python/CloudantApp.py
+++ b/examples/python/CloudantApp.py
@@ -98,3 +98,4 @@ flightData.printSchema()
 for code in flightData.collect():
 	print 'Flight {0} on {1}'.format(code.flightSegmentId, code.scheduledDepartureTime)
 
+sc.stop()

--- a/examples/python/CloudantDF.py
+++ b/examples/python/CloudantDF.py
@@ -63,3 +63,5 @@ print "Total", total, "flights from index"
 df = sqlContext.load(source="com.cloudant.spark", path="movies-glynn", view="_design/view1/_view/titleyear2")
 df.printSchema()
 df.filter(df.value.year >= 1950).select(df.value.title.alias("title"), df.value.year.alias("year")).show()
+
+sc.stop()

--- a/examples/python/CloudantDFOption.py
+++ b/examples/python/CloudantDFOption.py
@@ -20,7 +20,6 @@ from pyspark import SparkContext, SparkConf
 conf = SparkConf().setAppName("Cloudant Spark SQL External Datasource in Python")
 # define coudant related configuration
 conf.set("jsonstore.rdd.maxInPartition",1000)
-conf.set("jsonstore.rdd.concurrentSave",2)
 conf.set("jsonstore.rdd.bulkSize",10)
 
 sc = SparkContext(conf=conf)
@@ -57,3 +56,5 @@ df.printSchema()
 
 total = df.filter(df.flightSegmentId >'AA9').select("flightSegmentId", "scheduledDepartureTime").orderBy(df.flightSegmentId).count()
 print "Total", total, "flights from index"
+
+sc.stop()


### PR DESCRIPTION
The changes are in the following areas:
1. Distribute save across RDD partitions, which enables a better parallelism when RDD are distributed cross multiple nodes. Removed jsonstore.rdd.concurrentSave
2. Share ActorSystem across the duration of job. You need to do sparkconext.stop() for test to finish
3. fix NPE for CloudantApp.py caused by null returned from getConfig
4. Better exception when save failed. The reason is in the exception message
