### PR TITLE
[WIP] Register cloudant-spark with Spark Packages community index

### DIFF
--- a/cloudant-spark-sql/build.sbt
+++ b/cloudant-spark-sql/build.sbt
@@ -1,8 +1,8 @@
-organization  := "com.cloudant.spark"
+organization  := "cloudant-labs"
 
-name := "spark-sql"
+name := "spark-cloudant"
 
-version       := "0.1-SNAPSHOT"
+version       := "1.6.1"
 
 scalaVersion  := "2.10.4"
 
@@ -37,3 +37,25 @@ assemblyMergeStrategy in assembly := {
 }
 
 assemblyJarName in assembly := "cloudant-spark.jar"
+
+
+spAppendScalaVersion := true
+
+spName := "cloudant-labs/spark-cloudant"
+
+sparkVersion  := "1.5.1"
+
+sparkComponents := Seq("sql")
+
+spShortDescription := "Spark SQL Cloudant External Datasource"
+
+spDescription := """Spark SQL Cloudant External Datasource.
+                   |Cloudant integration with Spark as Spark SQL external datasource.
+                   | - Allows to load data from Cloudant dabases and indexes into Spark.
+                   | - Allows to save resulting data from Spark to existing Cloudant databases.
+                   | - Supports predicates push down (only based on _id field in databases, but varios fields for indexes).
+                   | - Support column pruning for indexes.""".stripMargin
+
+licenses += "Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0")
+
+credentials += Credentials(Path.userHome / ".ivy2" / ".sbtcredentials")

--- a/cloudant-spark-sql/project/plugins.sbt
+++ b/cloudant-spark-sql/project/plugins.sbt
@@ -1,0 +1,4 @@
+
+resolvers += "Spark Package Main Repo" at "https://dl.bintray.com/spark-packages/maven"
+
+addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.3")


### PR DESCRIPTION
Following instructions in the
https://github.com/databricks/sbt-spark-package

ToDo:
1) Create a file / ".ivy2" / ".sbtcredentials" with Github
cloudant-service user credentials

Registering and publishing Spark packages:
1) sbt spDist - creates a zip archive ready for a release on the Spark
packages website. The zip file will be produced in <project>/target.
2) sbt spRegister - registering Spark package in to the Spark Packages
website for the FIRST time only.
3) sbt spPublish - publish a new release.  First you should have pushed
your commit to the master branch on your remote, and you must be located
on the master branch.

After that anyone can use our spark package in pyspark or spark-submit
by using --packages com.cloudant.spark/cloudant-spark:0.1-SNAPSHOT

BugzID: 53022
