### PR TITLE
Message for saving data with 0 records

### DIFF
--- a/cloudant-spark-sql/src/main/scala/com/cloudant/spark/common/JsonStoreDataAccess.scala
+++ b/cloudant-spark-sql/src/main/scala/com/cloudant/spark/common/JsonStoreDataAccess.scala
@@ -195,6 +195,10 @@ class JsonStoreDataAccess (config: CloudantConfig)  {
   }
 
   def saveAll(rows: Array[String]) {
+    if (rows.size == 0) {
+      throw new RuntimeException("Database " + config.getDbname() +
+        ": nothing was saved because the number of records was 0!")
+    }
     implicit val (system, existing) = getSystem()
     import system.dispatcher 
     


### PR DESCRIPTION
When trying to save a dataframe with 0 records (for example a dataframe resulted from a filter operation), getting a division by zero the error.
An alternative to an error could be a message that nothing was saved because the number of records was 0.

BugzId: 61792

@HolgerKache @mayya-sharipova 
