### PR TITLE
Set up bulkSize on the level of dataframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ view||cloudant view w/o the database name. only used for load.
 index||cloudant search index w/o the database name. only used for load data with less than or equal to 200 results.
 path||cloudant: as database name if database is not present
 schemaSampleSize|1| the sample size used to discover the schema for this temp table. -1 scans all documents
+bulkSize|1| the bulk save size
 
 For fast loading, views are loaded without include_docs. Thus, a derived schema will always be: `{id, key, value}`, where `value `can be a compount field. An example of loading data from a view: 
 

--- a/cloudant-spark-sql/src/main/resources/application.conf
+++ b/cloudant-spark-sql/src/main/resources/application.conf
@@ -13,7 +13,7 @@ spark-sql {
   		minInPartition = 10
   		requestTimeout = 900000
   		concurrentSave = -1
-  		bulkSize = 1
+  		bulkSize = 100
   		schemaSampleSize = 1
   	}
 }

--- a/cloudant-spark-sql/src/main/scala/com/cloudant/spark/common/JsonStoreConfigManager.scala
+++ b/cloudant-spark-sql/src/main/scala/com/cloudant/spark/common/JsonStoreConfigManager.scala
@@ -39,6 +39,7 @@ import com.cloudant.spark.CloudantConfig
   val BULK_SIZE_CONFIG = "jsonstore.rdd.bulkSize"
   val SCHEMA_SAMPLE_SIZE_CONFIG = "jsonstore.rdd.schemaSampleSize"
   val PARAM_SCHEMA_SAMPLE_SIZE_CONFIG = "schemaSampleSize"
+  val PARAM_BULK_SIZE_CONFIG = "bulkSize"
   
   val configFactory = ConfigFactory.load()
 
@@ -113,7 +114,8 @@ import com.cloudant.spark.CloudantConfig
       
       implicit val requestTimeout =sparkConf.getLong(REQUEST_TIMEOUT_CONFIG,defaultRequestTimeout)
       implicit val concurrentSave =sparkConf.getInt(CONCURRENT_SAVE_CONFIG,defaultConcurrentSave)
-      implicit val bulkSize =sparkConf.getInt(BULK_SIZE_CONFIG,defaultBulkSize)
+      val bulkSizeS = parameters.getOrElse(PARAM_BULK_SIZE_CONFIG, null)
+      implicit val bulkSize = if (bulkSizeS == null) sparkConf.getInt(BULK_SIZE_CONFIG, defaultBulkSize) else bulkSizeS.toInt
 
       val dbName = parameters.getOrElse("database", parameters.getOrElse("path",null))
       val indexName = parameters.getOrElse("index",null)

--- a/examples/python/CloudantDF.py
+++ b/examples/python/CloudantDF.py
@@ -45,7 +45,7 @@ df.printSchema()
 
 df.filter(df.airportName >= 'Moscow').select("_id",'airportName').show()
 df.filter(df._id >= 'CAA').select("_id",'airportName').show()
-df.filter(df._id >= 'CAA').select("_id",'airportName').save("airportcodemapping_df", "com.cloudant.spark")
+df.filter(df._id >= 'CAA').select("_id",'airportName').save("airportcodemapping_df", "com.cloudant.spark", bulkSize = "22222222")
 
 df = sqlContext.load(source="com.cloudant.spark", database="n_flight")
 df.printSchema()

--- a/examples/python/CloudantDFOption.py
+++ b/examples/python/CloudantDFOption.py
@@ -44,7 +44,7 @@ df.cache() # persisting in memory
 df.printSchema()
 
 df.filter(df._id >= 'CAA').select("_id",'airportName').show()
-df.filter(df._id >= 'CAA').select("_id",'airportName').write.format("com.cloudant.spark").option("cloudant.host",cloudant_host).option("cloudant.username",cloudant_username).option("cloudant.password",cloudant_password).save("airportcodemapping_df")
+df.filter(df._id >= 'CAA').select("_id",'airportName').write.format("com.cloudant.spark").option("cloudant.host",cloudant_host).option("cloudant.username",cloudant_username).option("cloudant.password",cloudant_password).option("bulkSize","22222222").save("airportcodemapping_df")
 
 df = sqlContext.read.format("com.cloudant.spark").option("cloudant.host",cloudant_host).option("cloudant.username",cloudant_username).option("cloudant.password",cloudant_password).load("n_flight")
 df.printSchema()


### PR DESCRIPTION
It seems there is no way to modify SparkConf in Blumix. Because of this,we can't set up parameters such as jsonstore.rdd.bulkSize . These parameters should be also available to be set up on the level of dataframe or temp table.

BugzId: 61793

@HolgerKache @mayya-sharipova 
