### PR TITLE
make -1 a string

### DIFF
--- a/examples/ipython/python_Cloudant2.ipynb
+++ b/examples/ipython/python_Cloudant2.ipynb
@@ -59,7 +59,7 @@
     "# Connect to database 'sales' and read schema using all documents as schema sample size\n",
     "cloudantdata = sqlContext.read.format(\"com.cloudant.spark\").\\\n",
     "option(\"cloudant.host\",\"examples.cloudant.com\").\\\n",
-    "option(\"schemaSampleSize\", -1).\\\n",
+    "option(\"schemaSampleSize\", "-1").\\\n",
     "load(\"spark_sales\")\n",
     "\n",
     "# Print the schema that was detected\n",


### PR DESCRIPTION
sqlContext.read.format threw an error in a Bluemix Python notebook until I did this
